### PR TITLE
fix:画面幅変更によるスマホモードの引継ぎを修正

### DIFF
--- a/pages/creator/canvas.vue
+++ b/pages/creator/canvas.vue
@@ -552,6 +552,9 @@ export default defineComponent({
         const calculateWindowWidth = () => {
             mobileState.windowWidth = window.innerWidth;
             mobileState.mobileView = mobileState.windowWidth < 601;
+            if (!mobileState.mobileView) {
+                SettingModule.setReverseSmartPhoneMode(false);
+            }
             // タブレットの縦横が変わったときスクロール位置がリセットされてバグるため再設定
             const palletArea = document.querySelector('#palletArea')!;
             const layerWindow = document.querySelector('#layerList')!;


### PR DESCRIPTION
トグルボタンの状態がスマホモードフラグとバインドされていないのでスマホモード解除後もボタンはオンのままとなる不具合あり